### PR TITLE
Limit the Facebook page feed items

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Install
 
 ```
-virtualenv env -ppython3
+python3 -m venv env. env/bin/activate
 . env/bin/activate
 pip install -r requirements.txt
 python main.py

--- a/facebook.py
+++ b/facebook.py
@@ -14,7 +14,7 @@ class FacebookPost(ResponseEntity):
     link: Optional[str]
 
     @staticmethod
-    def from_api_entry(post: dict):
+    def from_api_entry(post: dict[str, str]):
         """
         Creates a dataclass instance out of Facebook API response
 
@@ -29,19 +29,25 @@ class FacebookPost(ResponseEntity):
         )
 
 
-def get_facebook_feed(feed_name: str, token: str) -> Iterable[FacebookPost]:
+def get_facebook_feed(feed_name: str, token: str, items_limit = None) -> Iterable[FacebookPost]:
     """
     Returns all posts from a given Facebook feed
     """
     logger = logging.getLogger('get_facebook_feed')
     logger.info(f'Getting the "{feed_name}" FB feed ...')
 
+    # https://developers.facebook.com/docs/graph-api/reference/v25.0/page/feed
+    # Maximum Posts:
+    #  * The API will return approximately 600 ranked, published posts per year.
+    #  * You can only read a maximum of 100 feed posts with the limit field.
+    #    If you try to read more than that you will get an error message to not exceed 100.
     feed = iterate_api_responses(endpoint=f"/v25.0/{feed_name}/feed", req_params={
         'fields': ','.join(
             ['full_picture', 'message', 'created_time', 'shares', 'permalink_url', 'attachments{url}']
         ),
+        'limit': 100,
         'access_token': token,
-    })
+    }, items_limit=items_limit)
 
     for entry in feed:
         logger.debug(f'Post: {entry}')

--- a/graph_api.py
+++ b/graph_api.py
@@ -7,6 +7,7 @@ from time import strptime, sleep
 from typing import Iterable
 
 from requests import Session
+from requests.exceptions import RequestException
 
 # keep the HTTP session
 http = Session()
@@ -33,9 +34,9 @@ class ResponseEntity:
         }
 
 
-def make_request(endpoint: str, req_params: dict, retries: int = 4) -> dict:
+def make_request(endpoint: str, req_params: dict, retries: int = 2) -> dict:
     logger = logging.getLogger('make_request')
-    retry_wait = 2  # seconds
+    retry_wait = 1  # seconds
 
     while retries > 0:
         try:
@@ -46,49 +47,59 @@ def make_request(endpoint: str, req_params: dict, retries: int = 4) -> dict:
             # ERROR:make_request:API response: {"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}
             sleep(3)
             return resp.json()
-        
+
         # Allow Ctrl+C to stop the script immediately, without waiting for retries
         except KeyboardInterrupt:
             raise
 
-        except:
+        except RequestException as ex:
             retries -= 1
             if retries == 0:
-                logger.error(f'API request to {endpoint} failed: {resp.text}', exc_info=True)
+                logger.error(f'API request to {endpoint} failed: {ex.response.text}', exc_info=True)
                 raise
 
-            logger.warning(f'API request to {endpoint} failed, retrying ({retries} retries left) after {retry_wait}s', exc_info=True)
+            logger.warning(f'API request to {endpoint} failed, retrying ({retries} retries left) after {retry_wait}s: : {ex.response.text}', exc_info=True)
 
             sleep(retry_wait)
             retry_wait *= 2  # exponential backoff
 
 
 
-def iterate_api_responses(endpoint: str, req_params: dict) -> Iterable[dict]:
+def iterate_api_responses(endpoint: str, req_params: dict, items_limit: int = None) -> Iterable[dict]:
     """
     Yields data items for all paged response of the given endpoint
     """
     logger = logging.getLogger('iterate_api_responses')
-    logger.info(f'HTTP request to {endpoint}')
+    logger.info(f'HTTP request to {endpoint} (with the items limit of {items_limit or "no limit"}) ...')
 
     items_counter = 0
 
-    while True:
-        resp_json = make_request(endpoint, req_params)
-        logger.debug('API response: %r', resp_json)
-        logger.debug('API paging: %r', resp_json.get('paging'))
+    try:
+        while True:
+            resp_json = make_request(endpoint, req_params)
+            logger.debug('API response: %r', resp_json)
+            logger.debug('API paging: %r', resp_json.get('paging'))
 
-        for item in resp_json.get('data', []):
-            items_counter += 1
-            yield item
+            for item in resp_json.get('data', []):
+                items_counter += 1
+                yield item
 
-        try:
-            req_params['after'] = resp_json['paging']['cursors']['after']
-            logger.debug('API next page (after) cursor: %r', req_params['after'])
-        except KeyError:
-            # no more pages to iterate over
-            logger.info(f'API returned {items_counter} items')
-            return
+                if items_limit and items_counter >= items_limit:
+                    logger.warning(f'API returned {items_counter} items (limit: {items_limit}), leaving early')
+                    return
+
+            try:
+                req_params['after'] = resp_json['paging']['cursors']['after']
+                logger.debug('API next page (after) cursor: %r', req_params['after'])
+            except KeyError:
+                # no more pages to iterate over
+                logger.info(f'API returned {items_counter} items')
+                return
+
+    except RequestException:
+        # ERROR:iterate_api_responses:Iterating on /v25.0/FarerskieKadry/feed failed after processing 300 items
+        logger.error(f'Iterating on {endpoint} failed after processing {items_counter} items')
+        raise
 
 
 # e.g. 2023-02-27T14:31:39+0000

--- a/main.py
+++ b/main.py
@@ -14,10 +14,14 @@ from facebook import get_facebook_feed
 from rss import RssFeedWriter
 from utils import response_entity_to_rss_item
 
+# ERROR:iterate_api_responses:Iterating on /v25.0/FarerskieKadry/feed failed after processing 300 items
+# {"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}
+ITEMS_LIMIT = 300
+
 
 # http://ndjson.org/
 def save_feed_to_ndjson(feed_name: str, access_token: str, output: TextIO):
-    for entry in get_facebook_feed(feed_name, access_token):
+    for entry in get_facebook_feed(feed_name, access_token, ITEMS_LIMIT):
         logging.info(f'{repr(entry)}')
 
         json.dump(entry.dict(), sort_keys=True, fp=output)
@@ -46,9 +50,9 @@ if __name__ == "__main__":
                 description='Suma miliona drobnych, banalnych sytuacji, miejsc, '
                             'ludzi uwiecznionych na cyfrowych kadrach i w nostalgicznych zakamarkach pamięci'
         ) as feed:
-            ig_feed = islice(get_facebook_feed(feed_name='FarerskieKadry', token=token), 30)
+            fb_feed = islice(get_facebook_feed(feed_name='FarerskieKadry', token=token, items_limit=ITEMS_LIMIT), 30)
 
-            for post in ig_feed:
+            for post in fb_feed:
                 # do not add posts that share links from the blog
                 if post.link and 'farerskiekadry.pl' in post.link:
                     continue


### PR DESCRIPTION
Fixes `{"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}`

```yaml
ERROR:iterate_api_responses:Iterating on /v25.0/FarerskieKadry/feed failed after processing 300 items
```